### PR TITLE
Changed SUDSTest module type from DeveloperTool to Editor

### DIFF
--- a/SUDS.uplugin
+++ b/SUDS.uplugin
@@ -26,7 +26,7 @@
     },
     {
       "Name": "SUDSTest",
-      "Type": "DeveloperTool",
+      "Type": "Editor",
       "LoadingPhase": "Default"
     }
   ]


### PR DESCRIPTION
Fixes standalone development build error caused by reference chain SUDSTest -> SUDSEditor -> UnrealEd.