### PR TITLE
Added test for `gosub` between speaker line and choices

### DIFF
--- a/Source/SUDSTest/Private/TestGotoGosub.cpp
+++ b/Source/SUDSTest/Private/TestGotoGosub.cpp
@@ -283,6 +283,39 @@ bool FTestGosubBetweenSpeakerAndChoice1::RunTest(const FString& Parameters)
 	return true;
 }
 
+
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestGosubBetweenSpeakerAndChoice1b,
+	"SUDSTest.TestGosubBetweenSpeakerAndChoice1b",
+	EAutomationTestFlags::EditorContext |
+	EAutomationTestFlags::ClientContext |
+	EAutomationTestFlags::ProductFilter)
+
+
+
+bool FTestGosubBetweenSpeakerAndChoice1b::RunTest(const FString& Parameters)
+{
+	FSUDSMessageLogger Logger(false);
+	FSUDSScriptImporter Importer;
+	TestTrue("Import should succeed", Importer.ImportFromBuffer(GetData(GosubBetweenSpeakerAndChoiceInput1), GosubBetweenSpeakerAndChoiceInput1.Len(), "GosubBetweenSpeakerAndChoiceInput1", &Logger, true));
+
+	auto Script = NewObject<USUDSScript>(GetTransientPackage(), "Test");
+	const ScopedStringTableHolder StringTableHolder;
+	Importer.PopulateAsset(Script, StringTableHolder.StringTable);
+
+	// Script shouldn't be the owner of the dialogue but it's the only UObject we've got right now so why not
+	auto Dlg = USUDSLibrary::CreateDialogue(Script, Script);
+	Dlg->SetVariableBoolean("SkipChoices", true);
+	Dlg->Start();
+
+
+	TestDialogueText(this, "Start node", Dlg, "Player", "Hello there");
+	TestTrue("Plain continue", Dlg->IsSimpleContinue());
+
+	Script->MarkAsGarbage();
+	return true;
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestGosubBetweenSpeakerAndChoice2,
 								 "SUDSTest.TestGosubBetweenSpeakerAndChoice2",
 								 EAutomationTestFlags::EditorContext |


### PR DESCRIPTION
Demonstrates that a conditional `goto` inside a `gosub` can not be used to hide choices.

This test fails, demonstrating issue #6. As a user, I was expecting to see the same behavior as in #7, meaning that I would see the choices if `SkipChoices == false` and I would not see the choices if `SkipChoices == true`.

I understand that it might be impossible to fix this, given how `goto` lines are resolved directly into node edges at parse-time and may not be aware of the `gosub` stack(s) they are inside.

Perhaps parsing `goto` lines into their own `SUDSScriptNodeGoto` which resolves at run-time would work, but I haven't thought it through.

Either way, this is not a critical bug for me as I can always work around it by inlining the `gosub` stack until the `goto` line is directly between the speaker line and the choices, see #7, so I'm just going to leave this here for documentation purposes.