### PR TITLE
Fix infinite loop when importing

### DIFF
--- a/Source/SUDSEditor/Private/SUDSScriptImporter.cpp
+++ b/Source/SUDSEditor/Private/SUDSScriptImporter.cpp
@@ -1702,6 +1702,8 @@ bool FSUDSScriptImporter::RecurseChoiceNodeCheckPaths(const FSUDSParsedNode& Cho
 			{
 				TargetNode = GetNode(TargetNode->Edges[0].TargetNodeIdx);
 			}
+			else // We reached the end of the script
+				return true;
 			break;
 		case ESUDSParsedNodeType::Gosub:
 		case ESUDSParsedNodeType::Return:


### PR DESCRIPTION
When importing any script, if the last line was an event call, the funciton `RecurseChoiceNodeCheckPaths()` would loop indefinitely causing the editor to get stuck!