### PR TITLE
Use `ETextIdenticalModeFlags::DeepCompare` flag for text comparsion

### DIFF
--- a/Source/SUDSTest/Private/TestChoiceSpeakerLines.cpp
+++ b/Source/SUDSTest/Private/TestChoiceSpeakerLines.cpp
@@ -61,7 +61,7 @@ bool FTestChoiceSpeakerLineInScript::RunTest(const FString& Parameters)
 	// Confirm that we got the choice as a speaker line
 	TestDialogueText(this, "Choice as speaker line 1", Dlg, "Player", "Choice 1");
 	// Confirm that text ID is the same
-	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText()));
+	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText(), ETextIdenticalModeFlags::DeepCompare));
 	TestEqual("TextIDs should match", FTextInspector::GetTextId(ChoiceText0).GetKey().GetChars(), FTextInspector::GetTextId(Dlg->GetText()).GetKey().GetChars());
 	
 	Dlg->Continue();
@@ -125,7 +125,7 @@ bool FTestChoiceSpeakerSetSpeakerIdInScriptInput::RunTest(const FString& Paramet
 	const FText ChoiceText0 = Dlg->GetChoiceText(0);
 	Dlg->Choose(0);
 	// Confirm that text ID is the same
-	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText()));
+	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText(), ETextIdenticalModeFlags::DeepCompare));
 	TestEqual("TextIDs should match", FTextInspector::GetTextId(ChoiceText0).GetKey().GetChars(), FTextInspector::GetTextId(Dlg->GetText()).GetKey().GetChars());
 	
 	// Confirm that we got the choice as a speaker line, with custom speaker ID
@@ -249,7 +249,7 @@ bool FTestChoicesAsSpeakerLineWithStringKeys::RunTest(const FString& Parameters)
 	// Confirm that we got the choice as a speaker line
 	TestDialogueText(this, "Choice as speaker line 1", Dlg, "Player", "Choice 1");
 	// Confirm that text ID is the same
-	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText()));
+	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText(), ETextIdenticalModeFlags::DeepCompare));
 	TestEqual("TextIDs should match", FTextInspector::GetTextId(ChoiceText0).GetKey().GetChars(), FTextInspector::GetTextId(Dlg->GetText()).GetKey().GetChars());
 	
 	Dlg->Continue();
@@ -264,7 +264,7 @@ bool FTestChoicesAsSpeakerLineWithStringKeys::RunTest(const FString& Parameters)
 	TestDialogueText(this, "Duplicated speaker line", Dlg, "Player", "Choice 1a");
 	
 	// Confirm that text ID is the same
-	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText()));
+	TestTrue("Text should be identical", ChoiceText0.IdenticalTo(Dlg->GetText(), ETextIdenticalModeFlags::DeepCompare));
 	TestEqual("TextIDs should match", FTextInspector::GetTextId(ChoiceText0).GetKey().GetChars(), FTextInspector::GetTextId(Dlg->GetText()).GetKey().GetChars());
 
 	Script->MarkAsGarbage();


### PR DESCRIPTION
With the default flag `ETextIdenticalModeFlags::None`, the first step of the comparison checks if the `TextData` pointers of the localized string pointers are identical. In the test case, the `TextData` pointers differ as the `FSUDSScriptImporter` creates them in separate `FTextInspector::GetTextId` calls. In the second step, pointers to the localized strings are compared. The localized string pointers can be `nullptr` if we don't have localization data. In such a case, the comparison returns false, and the tests fail.

With the flag `ETextIdenticalModeFlags::DeepCompare`, yet another step is executed. It checks if we create the test the same way (check `FTextHistory_StringTableEntry::FStringTableReferenceData::IsIdentical`).