### PR TITLE
Force "en-US" culture in some tests

### DIFF
--- a/Source/SUDSTest/Private/TestParameters.cpp
+++ b/Source/SUDSTest/Private/TestParameters.cpp
@@ -5,6 +5,7 @@
 #include "SUDSScriptImporter.h"
 #include "TestParticipant.h"
 #include "TestUtils.h"
+#include "Internationalization/Internationalization.h"
 #include "Misc/AutomationTest.h"
 
 UE_DISABLE_OPTIMIZATION
@@ -32,6 +33,15 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestParameters,
 
 bool FTestParameters::RunTest(const FString& Parameters)
 {
+	// Number and plural formatting are locale-specific, so we must set it to a predefined value to produce the expected output
+	FInternationalization::FCultureStateSnapshot CultureStateSnapshot;
+	FInternationalization::Get().BackupCultureState(CultureStateSnapshot);
+	FInternationalization::Get().SetCurrentCulture(TEXT("en-US"));
+	ON_SCOPE_EXIT
+	{
+		FInternationalization::Get().RestoreCultureState(CultureStateSnapshot);
+	};
+
 	FSUDSMessageLogger Logger(false);
 	FSUDSScriptImporter Importer;
 	TestTrue("Import should succeed", Importer.ImportFromBuffer(GetData(ParamsInput), ParamsInput.Len(), "ParamsInput", &Logger, true));
@@ -81,6 +91,14 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestParametersPriority,
 
 bool FTestParametersPriority::RunTest(const FString& Parameters)
 {
+	// Number and plural formatting are locale-specific, so we must set it to a predefined value to produce the expected output
+	FInternationalization::FCultureStateSnapshot CultureStateSnapshot;
+	FInternationalization::Get().BackupCultureState(CultureStateSnapshot);
+	FInternationalization::Get().SetCurrentCulture(TEXT("en-US"));
+	ON_SCOPE_EXIT
+	{
+		FInternationalization::Get().RestoreCultureState(CultureStateSnapshot);
+	};
 
 	FSUDSMessageLogger Logger(false);
 	FSUDSScriptImporter Importer;

--- a/Source/SUDSTest/Private/TestRunning.cpp
+++ b/Source/SUDSTest/Private/TestRunning.cpp
@@ -5,6 +5,7 @@
 #include "SUDSScriptImporter.h"
 #include "SUDSSubsystem.h"
 #include "TestUtils.h"
+#include "Internationalization/Internationalization.h"
 #include "Misc/AutomationTest.h"
 
 UE_DISABLE_OPTIMIZATION
@@ -222,6 +223,15 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestSetVariableRunning,
 
 bool FTestSetVariableRunning::RunTest(const FString& Parameters)
 {
+	// Number and plural formatting are locale-specific, so we must set it to a predefined value to produce the expected output
+	FInternationalization::FCultureStateSnapshot CultureStateSnapshot;
+	FInternationalization::Get().BackupCultureState(CultureStateSnapshot);
+	FInternationalization::Get().SetCurrentCulture(TEXT("en-US"));
+	ON_SCOPE_EXIT
+	{
+		FInternationalization::Get().RestoreCultureState(CultureStateSnapshot);
+	};
+
 	FSUDSMessageLogger Logger(false);
 	FSUDSScriptImporter Importer;
 	TestTrue("Import should succeed", Importer.ImportFromBuffer(GetData(SetVariableRunnerInput), SetVariableRunnerInput.Len(), "SetVariableRunnerInput", &Logger, true));


### PR DESCRIPTION
It fixes false-positive failures in tests with number, gender, and plural form formatting.

Number and plural formatting are locale-specific, so we must set it to a predefined value to produce the expected output in tests.

E.g. In Polish `,` is used as the decimal separator instead of `.`. Declaring people and numbers is much more complicated than in English.