### PR TITLE
Add support for dots in Event name literals

### DIFF
--- a/Source/SUDSEditor/Private/SUDSScriptImporter.cpp
+++ b/Source/SUDSEditor/Private/SUDSScriptImporter.cpp
@@ -1389,7 +1389,7 @@ bool FSUDSScriptImporter::ParseEventLine(const FStringView& Line,
                                          bool bSilent)
 {
 	const FString LineStr(Line);
-	const FRegexPattern EventPattern(TEXT("^\\[event\\s+(\\w+)([^\\]]*)\\]$"));
+	const FRegexPattern EventPattern(TEXT("^\\[event\\s+([\\w.]+)([^\\]]*)\\]$"));
 	FRegexMatcher EventRegex(EventPattern, LineStr);
 	if (EventRegex.FindNext())
 	{


### PR DESCRIPTION
Before this change a line like `[event Actor.Emote]` would send an event of name "Actor". This fixes it.