### PR TITLE
Fix UE5.6 compilation error

### DIFF
--- a/Source/SUDSEditor/Public/SUDSMessageLogger.h
+++ b/Source/SUDSEditor/Public/SUDSMessageLogger.h
@@ -24,8 +24,8 @@ public:
 	
 	bool GetWriteToMessageLog() const { return bWriteToMessageLog; }
 	void AddMessage(EMessageSeverity::Type Severity, const FText& Text);
-	template <typename FmtType, typename... Types>
-	FORCEINLINE void Logf(ELogVerbosity::Type Verbosity, const FmtType& Fmt, Types... Args)
+	template <typename... Types>
+	FORCEINLINE void Logf(ELogVerbosity::Type Verbosity, UE::Core::TCheckedFormatString<FString::FmtCharType, Types...> Fmt, Types... Args)
 	{
 		EMessageSeverity::Type Sev = EMessageSeverity::Info;
 		switch(Verbosity)

--- a/Source/SUDSEditor/Public/SUDSMessageLogger.h
+++ b/Source/SUDSEditor/Public/SUDSMessageLogger.h
@@ -24,8 +24,14 @@ public:
 	
 	bool GetWriteToMessageLog() const { return bWriteToMessageLog; }
 	void AddMessage(EMessageSeverity::Type Severity, const FText& Text);
+	
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6 
 	template <typename... Types>
 	FORCEINLINE void Logf(ELogVerbosity::Type Verbosity, UE::Core::TCheckedFormatString<FString::FmtCharType, Types...> Fmt, Types... Args)
+#else 
+	template <typename FmtType, typename... Types>
+	FORCEINLINE void Logf(ELogVerbosity::Type Verbosity, const FmtType& Fmt, Types... Args)
+#endif
 	{
 		EMessageSeverity::Type Sev = EMessageSeverity::Info;
 		switch(Verbosity)


### PR DESCRIPTION
UE5.6 adds a new TCheckedFormatString type. 

If `UE_VALIDATE_FORMAT_STRINGS` is defined (which it is by default as of target BuildSettingsVersion.V5), TCheckedFormatString has a consteval constructor. This errors because `Fmt` isn't compile-time constant within the `Logf` function.