### PR TITLE
Mark string table dirty when reimported

### DIFF
--- a/Source/SUDSEditor/Private/SUDSScriptFactory.cpp
+++ b/Source/SUDSEditor/Private/SUDSScriptFactory.cpp
@@ -134,6 +134,7 @@ UStringTable* USUDSScriptFactory::CreateStringTable(UObject* ScriptParent, FName
 					{
 						Table = Cast<UStringTable>(Assets[0].GetAsset());
 						Table->GetMutableStringTable()->ClearSourceStrings();
+						Table->MarkPackageDirty();
 					}
 					else
 					{


### PR DESCRIPTION
Otherwise the user isn't prompted to save, and the changes are lost on closing the editor (and the updated text never reaches cooked builds).