### PR TITLE
Fixed crash when importing empty script

### DIFF
--- a/Source/SUDSEditor/Private/SUDSScriptImporter.cpp
+++ b/Source/SUDSEditor/Private/SUDSScriptImporter.cpp
@@ -2166,8 +2166,11 @@ bool FSUDSScriptImporter::PostImportSanityCheck(const FString& NameForErrors, FS
 	// Now check everything is referenced
 	TArray<bool> ReferencedNodes;
 	ReferencedNodes.SetNumZeroed(BodyTree.Nodes.Num());
-	// First node is always reachable
-	ReferencedNodes[0] = true;
+	if (!ReferencedNodes.IsEmpty())
+	{
+		// First node is always reachable
+		ReferencedNodes[0] = true;
+	}
 	for (const auto& Goto : BodyTree.GotoLabelList)
 	{
 		// Goto creates a reference


### PR DESCRIPTION
I accidentally tried importing an empty .sud file and got a crash due to an assumption in `PostImportSanityCheck(..)`, that always at least one node gets parsed. All the other code in that method also works fine without any nodes, so I only had to add a small safeguard around the array access to handle this edge case ^^