### PR TITLE
Fixed crash when closing SUDSDialogueTab and reopening the editor

### DIFF
--- a/Source/SUDSEditor/Private/SUDSEditorToolkit.cpp
+++ b/Source/SUDSEditor/Private/SUDSEditorToolkit.cpp
@@ -168,43 +168,7 @@ void FSUDSEditorToolkit::RegisterTabSpawners(const TSharedRef<FTabManager>& InTa
 
 		ChoicesBox = SNew(SVerticalBox);
 
-		VariablesListView = SNew(SListView<TSharedPtr<FSUDSEditorVariableRow>>)
-#if ENGINE_MINOR_VERSION < 5
-				.ItemHeight(28)
-#endif
-				.SelectionMode(ESelectionMode::None)
-				.ListItemsSource(&VariableRows)
-				.OnGenerateRow(this, &FSUDSEditorToolkit::OnGenerateRowForVariable)
-				.HeaderRow(
-					SNew(SHeaderRow)
-					+ SHeaderRow::Column("NameHeader")
-					.FillSized(VarColumnWidth)
-					.VAlignCell(VAlign_Center)
-					[
-						SNew(SHorizontalBox)
-						+SHorizontalBox::Slot()
-						.AutoWidth()
-						.VAlign(VAlign_Center)
-						[
-							SNew( STextBlock )
-							.Text( INVTEXT("Name") )
-						]
-					]
-					+ SHeaderRow::Column("ValueHeader")
-					.FillWidth(1.0f)
-					.VAlignCell(VAlign_Fill)
-					[
-						SNew(SHorizontalBox)
-						+SHorizontalBox::Slot()
-						.AutoWidth()
-						.VAlign(VAlign_Center)
-						[
-							SNew( STextBlock )
-							.Text( INVTEXT("Value") )
-						]
-					]
-
-				);
+		CreateVariablesListViewIfUnset();
 
 		// To ensure globals are pre-populated
 		UpdateVariables();
@@ -231,6 +195,8 @@ void FSUDSEditorToolkit::RegisterTabSpawners(const TSharedRef<FTabManager>& InTa
 
 	InTabManager->RegisterTabSpawner("SUDSVariablesTab", FOnSpawnTab::CreateLambda([this](const FSpawnTabArgs&)
 	{
+		CreateVariablesListViewIfUnset();
+		
 		// Possibly use a SPropertyTable with a custom IPropertyTable to implement variable binding
 		return SNew(SDockTab)
 		[
@@ -664,6 +630,50 @@ void FSUDSEditorToolkit::UpdateChoiceButtons()
 		}
 	}
 	
+}
+
+void FSUDSEditorToolkit::CreateVariablesListViewIfUnset()
+{
+	if (VariablesListView.IsValid())
+		return;
+	
+	VariablesListView = SNew(SListView<TSharedPtr<FSUDSEditorVariableRow>>)
+#if ENGINE_MINOR_VERSION < 5
+		.ItemHeight(28)
+#endif
+		.SelectionMode(ESelectionMode::None)
+		.ListItemsSource(&VariableRows)
+		.OnGenerateRow(this, &FSUDSEditorToolkit::OnGenerateRowForVariable)
+		.HeaderRow(
+			SNew(SHeaderRow)
+			+ SHeaderRow::Column("NameHeader")
+			.FillSized(VarColumnWidth)
+			.VAlignCell(VAlign_Center)
+			[
+				SNew(SHorizontalBox)
+				+SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				[
+					SNew( STextBlock )
+					.Text( INVTEXT("Name") )
+				]
+			]
+			+ SHeaderRow::Column("ValueHeader")
+			.FillWidth(1.0f)
+			.VAlignCell(VAlign_Fill)
+			[
+				SNew(SHorizontalBox)
+				+SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				[
+					SNew( STextBlock )
+					.Text( INVTEXT("Value") )
+				]
+			]
+
+		);
 }
 
 void FSUDSEditorToolkit::OnDialogueChoice(USUDSDialogue* D, int ChoiceIndex, int LineNo)

--- a/Source/SUDSEditor/Private/SUDSEditorToolkit.h
+++ b/Source/SUDSEditor/Private/SUDSEditorToolkit.h
@@ -304,6 +304,7 @@ private:
 	void DestroyDialogue();
 	void UpdateOutput();
 	void UpdateChoiceButtons();
+	void CreateVariablesListViewIfUnset();
 	void AddOutputRow(const FText& Prefix, const FText& Line, const FSlateColor& PrefixColour, const FSlateColor& LineColour);
 	void AddTraceLogRow(const FName& Category, int SourceLineNo, const FString& Message);
 


### PR DESCRIPTION
In our team, someone accidentally closed the "Dialogue Output" tab in the SUD asset editor. From then on, they couldn't open the asset editor anymore without getting an instant crash D:

I found the root cause to be that the "Variables" tab during creation expects `VariablesListView` to be already set. `VariablesListView` is set during creation of the "Dialogue Output" tab, which explains the crash when that tab is closed and the editor reopened!

The fix proposal is to extract creation of `VariablesListView` into a method that is called during creation of both these tabs, and which guarantees the view is created when it hasn't been.